### PR TITLE
Use different constructor of HttpMessageNotReadableException in the M…

### DIFF
--- a/src/main/java/com/googlecode/jsonrpc4j/spring/rest/MappingJacksonRPC2HttpMessageConverter.java
+++ b/src/main/java/com/googlecode/jsonrpc4j/spring/rest/MappingJacksonRPC2HttpMessageConverter.java
@@ -138,13 +138,17 @@ class MappingJacksonRPC2HttpMessageConverter extends AbstractHttpMessageConverte
 
 	@Override
 	protected Object readInternal(Class<?> clazz, HttpInputMessage inputMessage)
-			throws IOException, HttpMessageNotReadableException {
+		throws HttpMessageNotReadableException {
 
 		JavaType javaType = getJavaType(clazz);
 		try {
 			return this.objectMapper.readValue(inputMessage.getBody(), javaType);
 		} catch (IOException ex) {
-			throw new HttpMessageNotReadableException("Could not read JSON: " + ex.getMessage(), ex);
+			throw new HttpMessageNotReadableException(
+				"Could not read JSON: " + ex.getMessage(),
+				ex,
+				inputMessage
+			);
 		}
 	}
 


### PR DESCRIPTION
…appingJacksonRPC2HttpMessageConverter.readInternal()

Spring Framework 5.1 (spring-web) has deprecated the usage of constructor without httpInputMessage parameter. Other constructor needs to be used instead.